### PR TITLE
Adapt matrix transforms for Flutter 3.47

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '11'
+          java-version: '17'
       - name: flutter hotbake
         run: |
           flutter doctor --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 8 1/7 * *'
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,10 @@
 name: Flutter Build Test CI
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 8 1/7 * *'
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/lib/src/indicators/audio_equalizer.dart
+++ b/lib/src/indicators/audio_equalizer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// AudioEqualizer
 class AudioEqualizer extends StatefulWidget {
@@ -69,7 +70,8 @@ class _AudioEqualizerState extends State<AudioEqualizer>
             builder: (_, child) {
               return Transform(
                 transform: Matrix4.identity()
-                  ..scale(1.0, _animations[i ~/ 2].value),
+                  ..scaleWithValues(
+                      1.0, _animations[i ~/ 2].value, 1.0, 1.0),
                 alignment: Alignment.bottomCenter,
                 child: child,
               );

--- a/lib/src/indicators/ball_clip_rotate.dart
+++ b/lib/src/indicators/ball_clip_rotate.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallClipRotate.
 class BallClipRotate extends StatefulWidget {
@@ -51,7 +52,8 @@ class _BallClipRotateState extends State<BallClipRotate>
         return Transform(
           alignment: Alignment.center,
           transform: Matrix4.identity()
-            ..scale(_scaleAnimation.value)
+            ..scaleWithValues(_scaleAnimation.value, _scaleAnimation.value,
+                _scaleAnimation.value, 1.0)
             ..rotateZ(_rotateAnimation.value),
           child: child,
         );

--- a/lib/src/indicators/ball_clip_rotate_multiple.dart
+++ b/lib/src/indicators/ball_clip_rotate_multiple.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallClipRotateMultiple.
 class BallClipRotateMultiple extends StatefulWidget {
@@ -53,7 +54,8 @@ class _BallClipRotateMultipleState extends State<BallClipRotateMultiple>
             Transform(
               alignment: Alignment.center,
               transform: Matrix4.identity()
-                ..scale(_scaleAnimation.value)
+                ..scaleWithValues(_scaleAnimation.value, _scaleAnimation.value,
+                    _scaleAnimation.value, 1.0)
                 ..rotateZ(_rotateAnimation.value),
               child: child,
             ),
@@ -65,7 +67,8 @@ class _BallClipRotateMultipleState extends State<BallClipRotateMultiple>
               child: Transform(
                 alignment: Alignment.center,
                 transform: Matrix4.identity()
-                  ..scale(_scaleAnimation.value)
+                  ..scaleWithValues(_scaleAnimation.value, _scaleAnimation.value,
+                      _scaleAnimation.value, 1.0)
                   ..rotateZ(-_rotateAnimation.value),
                 child: child,
               ),

--- a/lib/src/indicators/ball_clip_rotate_pulse.dart
+++ b/lib/src/indicators/ball_clip_rotate_pulse.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallClipRotatePulse.
 class BallClipRotatePulse extends StatefulWidget {
@@ -55,7 +56,8 @@ class _BallClipRotatePulseState extends State<BallClipRotatePulse>
           Transform(
             alignment: Alignment.center,
             transform: Matrix4.identity()
-              ..scale(_outCircleScale.value)
+              ..scaleWithValues(_outCircleScale.value, _outCircleScale.value,
+                  _outCircleScale.value, 1.0)
               ..rotateZ(_outCircleRotate.value),
             child: const IndicatorShapeWidget(
               shape: Shape.ringTwoHalfVertical,

--- a/lib/src/indicators/ball_pulse_rise.dart
+++ b/lib/src/indicators/ball_pulse_rise.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallPulseRise.
 class BallPulseRise extends StatefulWidget {
@@ -86,17 +87,17 @@ class _BallPulseRiseState extends State<BallPulseRise>
     return AnimatedBuilder(
       animation: _animationController,
       builder: (_, child) {
+        final scale = index.isEven
+            ? _evenScaleAnimation.value
+            : _oddScaleAnimation.value;
+        final translateY = index.isEven
+            ? _evenTranslateAnimation.value * deltaY
+            : _oddTranslateAnimation.value * deltaY;
         return Transform(
           alignment: Alignment.center,
           transform: Matrix4.identity()
-            ..scale(index.isEven
-                ? _evenScaleAnimation.value
-                : _oddScaleAnimation.value)
-            ..translate(
-                0.0,
-                index.isEven
-                    ? _evenTranslateAnimation.value * deltaY
-                    : _oddTranslateAnimation.value * deltaY)
+            ..scaleWithValues(scale, scale, scale, 1.0)
+            ..translateWithValues(0.0, translateY, 0.0, 1.0)
             ..setEntry(3, 2, 0.006),
           child: child,
         );

--- a/lib/src/indicators/ball_rotate_chase.dart
+++ b/lib/src/indicators/ball_rotate_chase.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallRotateChase.
 class BallRotateChase extends StatefulWidget {
@@ -62,9 +63,11 @@ class _BallRotateChaseState extends State<BallRotateChase>
               return Transform(
                 alignment: Alignment.center,
                 transform: Matrix4.identity()
-                  ..translate(
+                  ..translateWithValues(
                     deltaX * sin(_translateAnimations[i].value),
                     deltaY * -cos(_translateAnimations[i].value),
+                    0.0,
+                    1.0,
                   ),
 
                 /// scale must in child, if upper would align topLeft.

--- a/lib/src/indicators/ball_triangle_path.dart
+++ b/lib/src/indicators/ball_triangle_path.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallTrianglePath.
 class BallTrianglePath extends StatefulWidget {
@@ -111,9 +112,11 @@ class _BallTrianglePathState extends State<BallTrianglePath>
       builder: (_, child) {
         return Transform(
           transform: Matrix4.identity()
-            ..translate(
+            ..translateWithValues(
               animation.value.dx * (size.width - circleSize),
               animation.value.dy * (size.height - circleSize),
+              0.0,
+              1.0,
             ),
           child: child,
         );

--- a/lib/src/indicators/ball_triangle_path_colored.dart
+++ b/lib/src/indicators/ball_triangle_path_colored.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallTrianglePath.
 class BallTrianglePathColored extends StatefulWidget {
@@ -111,9 +112,11 @@ class _BallTrianglePathColoredState extends State<BallTrianglePathColored>
       builder: (_, child) {
         return Transform(
           transform: Matrix4.identity()
-            ..translate(
+            ..translateWithValues(
               animation!.value.dx * (size.width - circleSize),
               animation.value.dy * (size.height - circleSize),
+              0.0,
+              1.0,
             ),
           child: child,
         );

--- a/lib/src/indicators/ball_zig_zag.dart
+++ b/lib/src/indicators/ball_zig_zag.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallZigZag.
 class BallZigZag extends StatefulWidget {
@@ -59,8 +60,8 @@ class _BallZigZagState extends State<BallZigZag>
                 rect: Rect.fromLTWH(deltaX, deltaY, circleSize, circleSize),
                 child: Transform(
                   transform: Matrix4.identity()
-                    ..translate(deltaX * _animation.value.dx,
-                        deltaY * _animation.value.dy),
+                    ..translateWithValues(deltaX * _animation.value.dx,
+                        deltaY * _animation.value.dy, 0.0, 1.0),
                   child: const IndicatorShapeWidget(
                     shape: Shape.circle,
                     index: 0,
@@ -71,8 +72,8 @@ class _BallZigZagState extends State<BallZigZag>
                 rect: Rect.fromLTWH(deltaX, deltaY, circleSize, circleSize),
                 child: Transform(
                   transform: Matrix4.identity()
-                    ..translate(deltaX * -_animation.value.dx,
-                        deltaY * -_animation.value.dy),
+                    ..translateWithValues(deltaX * -_animation.value.dx,
+                        deltaY * -_animation.value.dy, 0.0, 1.0),
                   child: const IndicatorShapeWidget(
                     shape: Shape.circle,
                     index: 1,

--- a/lib/src/indicators/ball_zig_zag_deflect.dart
+++ b/lib/src/indicators/ball_zig_zag_deflect.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// BallZigZagDeflect.
 class BallZigZagDeflect extends StatefulWidget {
@@ -58,8 +59,8 @@ class _BallZigZagDeflectState extends State<BallZigZagDeflect>
               rect: Rect.fromLTWH(deltaX, deltaY, circleSize, circleSize),
               child: Transform(
                 transform: Matrix4.identity()
-                  ..translate(deltaX * _animation.value.dx,
-                      deltaY * _animation.value.dy),
+                  ..translateWithValues(deltaX * _animation.value.dx,
+                      deltaY * _animation.value.dy, 0.0, 1.0),
                 child: const IndicatorShapeWidget(
                   shape: Shape.circle,
                   index: 0,
@@ -70,8 +71,8 @@ class _BallZigZagDeflectState extends State<BallZigZagDeflect>
               rect: Rect.fromLTWH(deltaX, deltaY, circleSize, circleSize),
               child: Transform(
                 transform: Matrix4.identity()
-                  ..translate(deltaX * -_animation.value.dx,
-                      deltaY * -_animation.value.dy),
+                  ..translateWithValues(deltaX * -_animation.value.dx,
+                      deltaY * -_animation.value.dy, 0.0, 1.0),
                 child: const IndicatorShapeWidget(
                   shape: Shape.circle,
                   index: 1,

--- a/lib/src/indicators/cube_transition.dart
+++ b/lib/src/indicators/cube_transition.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// CubeTransition.
 class CubeTransition extends StatefulWidget {
@@ -86,10 +87,14 @@ class _CubeTransitionState extends State<CubeTransition>
               child: Transform(
                 alignment: Alignment.center,
                 transform: Matrix4.identity()
-                  ..translate(_translateAnimation.value!.width * deltaX,
-                      _translateAnimation.value!.height * deltaY)
+                  ..translateWithValues(
+                      _translateAnimation.value!.width * deltaX,
+                      _translateAnimation.value!.height * deltaY,
+                      0.0,
+                      1.0)
                   ..rotateZ(_rotateAnimation.value)
-                  ..scale(_scaleAnimation.value),
+                  ..scaleWithValues(_scaleAnimation.value, _scaleAnimation.value,
+                      _scaleAnimation.value, 1.0),
                 child: const IndicatorShapeWidget(
                   shape: Shape.rectangle,
                   index: 0,
@@ -102,10 +107,14 @@ class _CubeTransitionState extends State<CubeTransition>
               child: Transform(
                 alignment: Alignment.center,
                 transform: Matrix4.identity()
-                  ..translate(-_translateAnimation.value!.width * deltaX,
-                      -_translateAnimation.value!.height * deltaY)
+                  ..translateWithValues(
+                      -_translateAnimation.value!.width * deltaX,
+                      -_translateAnimation.value!.height * deltaY,
+                      0.0,
+                      1.0)
                   ..rotateZ(_rotateAnimation.value)
-                  ..scale(_scaleAnimation.value),
+                  ..scaleWithValues(_scaleAnimation.value, _scaleAnimation.value,
+                      _scaleAnimation.value, 1.0),
                 child: const IndicatorShapeWidget(
                   shape: Shape.rectangle,
                   index: 1,

--- a/lib/src/transition/matrix4_transform.dart
+++ b/lib/src/transition/matrix4_transform.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+/// Strongly typed matrix transforms that keep compatibility with Flutter
+/// versions whose bundled vector_math predates 2.2.0.
+extension Matrix4Transform on Matrix4 {
+  void translateWithValues(double tx, double ty, double tz, double tw) {
+    final values = storage;
+    final t1 =
+        values[0] * tx + values[4] * ty + values[8] * tz + values[12] * tw;
+    final t2 =
+        values[1] * tx + values[5] * ty + values[9] * tz + values[13] * tw;
+    final t3 =
+        values[2] * tx + values[6] * ty + values[10] * tz + values[14] * tw;
+    final t4 =
+        values[3] * tx + values[7] * ty + values[11] * tz + values[15] * tw;
+    values[12] = t1;
+    values[13] = t2;
+    values[14] = t3;
+    values[15] = t4;
+  }
+
+  void scaleWithValues(double sx, double sy, double sz, double sw) {
+    final values = storage;
+    values[0] *= sx;
+    values[1] *= sx;
+    values[2] *= sx;
+    values[3] *= sx;
+    values[4] *= sy;
+    values[5] *= sy;
+    values[6] *= sy;
+    values[7] *= sy;
+    values[8] *= sz;
+    values[9] *= sz;
+    values[10] *= sz;
+    values[11] *= sz;
+    values[12] *= sw;
+    values[13] *= sw;
+    values[14] *= sw;
+    values[15] *= sw;
+  }
+}

--- a/lib/src/transition/scale_y_transition.dart
+++ b/lib/src/transition/scale_y_transition.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 /// Animates the y axis scale of a transformed widget.
 class ScaleYTransition extends AnimatedWidget {
@@ -18,7 +19,8 @@ class ScaleYTransition extends AnimatedWidget {
   @override
   Widget build(BuildContext context) {
     final double scaleYValue = scaleY.value;
-    final Matrix4 transform = Matrix4.identity()..scale(1.0, scaleYValue, 1.0);
+    final Matrix4 transform = Matrix4.identity()
+      ..scaleWithValues(1.0, scaleYValue, 1.0, 1.0);
     return Transform(
       transform: transform,
       alignment: alignment,

--- a/test/loading_test.dart
+++ b/test/loading_test.dart
@@ -1,7 +1,85 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:loading_indicator/loading_indicator.dart';
+import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 void main() {
-  test('nothing here', () {
-    // Nothing to test
+  group('Matrix4Transform', () {
+    test('translates using homogeneous coordinates', () {
+      final matrix = Matrix4.identity()
+        ..translateWithValues(2.0, 3.0, 4.0, 1.0);
+
+      expect(
+        matrix.storage,
+        orderedEquals([
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          1.0,
+          0.0,
+          2.0,
+          3.0,
+          4.0,
+          1.0,
+        ]),
+      );
+    });
+
+    test('scales each matrix column', () {
+      final matrix = Matrix4.identity()..scaleWithValues(2.0, 3.0, 4.0, 1.0);
+
+      expect(
+        matrix.storage,
+        orderedEquals([
+          2.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          3.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          4.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          1.0,
+        ]),
+      );
+    });
+  });
+
+  testWidgets('builds every indicator without errors', (tester) async {
+    for (final indicator in Indicator.values) {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox.square(
+              dimension: 100,
+              child: LoadingIndicator(indicatorType: indicator),
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: '$indicator should build without errors',
+      );
+    }
+
+    await tester.pumpWidget(const SizedBox.shrink());
   });
 }


### PR DESCRIPTION
## Summary

- replace deprecated dynamic Matrix4 scale and translate calls with typed compatibility helpers
- preserve support for Flutter versions bundled with vector_math before 2.2.0
- add matrix and all-indicator widget regression coverage

## Testing

- flutter analyze
- flutter test
- flutter build macos --debug
- flutter run --no-pub -d macos

Fixes #45