### PR TITLE
Respect strokeWidth in lineSpinFadeLoader

### DIFF
--- a/lib/src/decorate/decorate.dart
+++ b/lib/src/decorate/decorate.dart
@@ -32,6 +32,10 @@ class DecorateData {
 
   double get strokeWidth => _strokeWidth ?? _kDefaultStrokeWidth;
 
+  /// The explicitly configured stroke width, or null when the indicator
+  /// should keep its size-derived default.
+  double? get configuredStrokeWidth => _strokeWidth;
+
   Function get _deepEq => const DeepCollectionEquality().equals;
 
   @override

--- a/lib/src/indicators/line_spin_fade_loader.dart
+++ b/lib/src/indicators/line_spin_fade_loader.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:loading_indicator/src/decorate/decorate.dart';
 import 'package:loading_indicator/src/indicators/base/indicator_controller.dart';
 import 'package:loading_indicator/src/shape/indicator_painter.dart';
 
@@ -46,6 +47,8 @@ class _LineSpinFadeLoaderState extends State<LineSpinFadeLoader>
 
   @override
   Widget build(BuildContext context) {
+    final lineWidth =
+        DecorateContext.of(context)!.decorateData.configuredStrokeWidth;
     return LayoutBuilder(builder: (ctx, constraint) {
       final circleSize = constraint.maxWidth / 3;
 
@@ -66,6 +69,7 @@ class _LineSpinFadeLoaderState extends State<LineSpinFadeLoader>
               angle: -angle,
               child: IndicatorShapeWidget(
                 shape: Shape.line,
+                lineWidth: lineWidth,
                 index: i,
               ),
             ),

--- a/lib/src/shape/indicator_painter.dart
+++ b/lib/src/shape/indicator_painter.dart
@@ -22,6 +22,7 @@ enum Shape {
 class IndicatorShapeWidget extends StatelessWidget {
   final Shape shape;
   final double? data;
+  final double? lineWidth;
 
   /// The index of shape in the widget.
   final int index;
@@ -30,6 +31,7 @@ class IndicatorShapeWidget extends StatelessWidget {
     Key? key,
     required this.shape,
     this.data,
+    this.lineWidth,
     this.index = 0,
   }) : super(key: key);
 
@@ -49,6 +51,7 @@ class IndicatorShapeWidget extends StatelessWidget {
           shape,
           data,
           decorateData.strokeWidth,
+          lineWidth: lineWidth,
           pathColor: decorateData.pathBackgroundColor,
         ),
       ),
@@ -62,6 +65,7 @@ class _ShapePainter extends CustomPainter {
   final Paint _paint;
   final double? data;
   final double strokeWidth;
+  final double? lineWidth;
   final Color? pathColor;
 
   _ShapePainter(
@@ -69,6 +73,7 @@ class _ShapePainter extends CustomPainter {
     this.shape,
     this.data,
     this.strokeWidth, {
+    this.lineWidth,
     this.pathColor,
   })  : _paint = Paint()..isAntiAlias = true,
         super();
@@ -141,11 +146,25 @@ class _ShapePainter extends CustomPainter {
         _paint
           ..color = color
           ..style = PaintingStyle.fill;
+        final configuredLineWidth = lineWidth;
+        final lineRect =
+            configuredLineWidth == null ||
+                !configuredLineWidth.isFinite ||
+                configuredLineWidth <= 0 ||
+                configuredLineWidth >= size.shortestSide
+            ? Offset.zero & size
+            : Rect.fromCenter(
+                center: size.center(Offset.zero),
+                width: configuredLineWidth,
+                height: size.height,
+              );
         canvas.drawRRect(
-            RRect.fromRectAndRadius(
-                Rect.fromLTWH(0, 0, size.width, size.height),
-                Radius.circular(size.shortestSide / 2)),
-            _paint);
+          RRect.fromRectAndRadius(
+            lineRect,
+            Radius.circular(lineRect.shortestSide / 2),
+          ),
+          _paint,
+        );
         break;
       case Shape.triangle:
         final offsetY = size.height / 4;
@@ -182,5 +201,6 @@ class _ShapePainter extends CustomPainter {
       color != oldDelegate.color ||
       data != oldDelegate.data ||
       strokeWidth != oldDelegate.strokeWidth ||
+      lineWidth != oldDelegate.lineWidth ||
       pathColor != oldDelegate.pathColor;
 }

--- a/test/loading_test.dart
+++ b/test/loading_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:loading_indicator/loading_indicator.dart';
+import 'package:loading_indicator/src/shape/indicator_painter.dart';
 import 'package:loading_indicator/src/transition/matrix4_transform.dart';
 
 void main() {
@@ -81,5 +82,42 @@ void main() {
     }
 
     await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('lineSpinFadeLoader respects strokeWidth', (tester) async {
+    Future<void> pumpIndicator(double? strokeWidth) {
+      return tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox.square(
+              dimension: 96,
+              child: LoadingIndicator(
+                indicatorType: Indicator.lineSpinFadeLoader,
+                colors: const [Colors.blue],
+                strokeWidth: strokeWidth,
+                pause: true,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    List<IndicatorShapeWidget> lineShapes() => tester
+        .widgetList<IndicatorShapeWidget>(find.byType(IndicatorShapeWidget))
+        .where((widget) => widget.shape == Shape.line)
+        .toList();
+
+    await pumpIndicator(null);
+    expect(lineShapes(), hasLength(8));
+    expect(lineShapes().map((shape) => shape.lineWidth), everyElement(isNull));
+
+    await pumpIndicator(2);
+    expect(lineShapes(), hasLength(8));
+    expect(lineShapes().map((shape) => shape.lineWidth), everyElement(2));
+
+    await pumpIndicator(12);
+    expect(lineShapes(), hasLength(8));
+    expect(lineShapes().map((shape) => shape.lineWidth), everyElement(12));
   });
 }


### PR DESCRIPTION
## Summary
- apply an explicitly configured stroke width to lineSpinFadeLoader
- preserve the existing size-derived width when strokeWidth is omitted
- center custom-width lines and repaint when the width changes
- add regression coverage for default and custom widths

## Testing
- flutter test --no-pub
- flutter analyze --no-pub
- macOS debug build and interactive UI comparison

Fixes #35