### PR TITLE
Automate GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Publish GitHub Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+
+jobs:
+  release:
+    name: Create release notes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: >-
+          gh release create "$GITHUB_REF_NAME"
+          --verify-tag
+          --generate-notes
+          --title "$GITHUB_REF_NAME"


### PR DESCRIPTION
## Summary

- add a tag-triggered GitHub Release workflow
- generate release notes from the previous release with the GitHub CLI
- support both X.Y.Z and vX.Y.Z tag conventions
- limit the workflow token to contents: write

## Validation

- parsed the workflow with Ruby YAML
- verified the GitHub CLI release flags
- ran git diff --check
- Flutter tests not run because only GitHub Actions YAML changed