### PR TITLE
Automate pub.dev publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions: {}
+
+concurrency:
+  group: pub-dev-${{ github.ref }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pub.dev
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Set up Dart and pub.dev authentication
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+      - name: Set up Flutter
+        uses: flutter-actions/setup-flutter@d4e97a6e7467ef062618c9af927f90bc9651b876
+      - name: Install dependencies
+        run: dart pub get
+      - name: Validate package
+        run: dart pub publish --dry-run
+      - name: Publish package
+        run: dart pub publish --force


### PR DESCRIPTION
## Summary

- publish matching X.Y.Z tags to pub.dev through GitHub OIDC
- require the pub.dev GitHub Environment for release approval
- grant only contents: read and id-token: write
- pin every external Action to a full commit SHA
- validate the package before the irreversible publish step

## Validation

- Flutter 3.47.1 / Dart 3.13.1
- flutter pub publish --dry-run passed for loading_indicator 4.0.0 with 0 warnings
- workflow YAML parsing passed
- git diff --check passed

## Required setup before tagging 4.0.0

1. In https://pub.dev/packages/loading_indicator/admin, enable GitHub Actions automated publishing.
2. Set repository to TinoGuo/loading_indicator and tag pattern to {{version}}.
3. Require the GitHub Actions environment named pub.dev.
4. In GitHub repository settings, configure the pub.dev environment and its required reviewer.