### PR TITLE
Update all GitHub Actions to latest releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: 'stable'
       - if: matrix.os == 'macos-latest'
         name: set java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
@@ -56,7 +56,7 @@ jobs:
         run: flutter build web
       - if: ${{ matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master' }}
         name: deploy
-        uses: JamesIves/github-pages-deploy-action@v4.9.0
+        uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: example/build/web # The folder the action should deploy.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Dart and pub.dev authentication
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
       - name: Set up Flutter

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Dart and pub.dev authentication
-        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        uses: dart-lang/setup-dart@7654d458321ee25acccccfdb86cd48bd95768ff1 # v1.8.0
       - name: Set up Flutter
-        uses: flutter-actions/setup-flutter@d4e97a6e7467ef062618c9af927f90bc9651b876
+        uses: flutter-actions/setup-flutter@adb607ae976a9e00473569facfc69813c637a060 # v4.3
       - name: Install dependencies
         run: dart pub get
       - name: Validate package


### PR DESCRIPTION
## Summary

Audit every external Action referenced by the repository workflows and update each reference to the latest stable release, pinned to a full commit SHA.

| Action | Previous | Updated |
| --- | --- | --- |
| actions/checkout | v7 tag / v6 SHA | v7.0.1 SHA |
| subosito/flutter-action | v2 tag | v2.23.0 SHA |
| actions/setup-java | v5 tag | v6.0.0 SHA |
| JamesIves/github-pages-deploy-action | v4.9.0 tag | v4.9.0 SHA |
| dart-lang/setup-dart | v1.7.1 SHA | v1.8.0 SHA |
| flutter-actions/setup-flutter | older SHA | v4.3 SHA |

The GitHub release workflow uses the preinstalled GitHub CLI and has no external Action dependency.

## Validation

- verified every version and SHA against the upstream repository release and tag APIs
- parsed all three workflow YAML files successfully
- git diff --check passed
- loading_indicator 4.0.0 pub publish dry-run passed with 0 warnings in #55

The setup-java v6 release notes explicitly state that its ESM migration is not a user-facing breaking change; the existing Temurin Java 17 inputs remain supported.