### PR TITLE
Fix pub.dev static analysis score

### DIFF
--- a/lib/src/indicators/ball_pulse_rise.dart
+++ b/lib/src/indicators/ball_pulse_rise.dart
@@ -83,13 +83,12 @@ class _BallPulseRiseState extends State<BallPulseRise>
     );
   }
 
-  _buildSingleCircle(int index, double deltaY) {
+  Widget _buildSingleCircle(int index, double deltaY) {
     return AnimatedBuilder(
       animation: _animationController,
       builder: (_, child) {
-        final scale = index.isEven
-            ? _evenScaleAnimation.value
-            : _oddScaleAnimation.value;
+        final scale =
+            index.isEven ? _evenScaleAnimation.value : _oddScaleAnimation.value;
         final translateY = index.isEven
             ? _evenTranslateAnimation.value * deltaY
             : _oddTranslateAnimation.value * deltaY;

--- a/lib/src/indicators/ball_rotate.dart
+++ b/lib/src/indicators/ball_rotate.dart
@@ -56,7 +56,7 @@ class _BallRotateState extends State<BallRotate>
     );
   }
 
-  _buildSingleCircle(
+  Widget _buildSingleCircle(
     double opacity,
     int index,
   ) {

--- a/lib/src/indicators/ball_triangle_path.dart
+++ b/lib/src/indicators/ball_triangle_path.dart
@@ -101,7 +101,7 @@ class _BallTrianglePathState extends State<BallTrianglePath>
     );
   }
 
-  _buildAnimatedRing(
+  Widget _buildAnimatedRing(
     Size size,
     double circleSize,
     Animation<Offset> animation,

--- a/lib/src/indicators/ball_triangle_path_colored.dart
+++ b/lib/src/indicators/ball_triangle_path_colored.dart
@@ -105,7 +105,7 @@ class _BallTrianglePathColoredState extends State<BallTrianglePathColored>
     );
   }
 
-  _buildAnimatedRing(
+  Widget _buildAnimatedRing(
       Size size, double circleSize, Animation<Offset>? animation, int index) {
     return AnimatedBuilder(
       animation: _animationController,

--- a/lib/src/loading.dart
+++ b/lib/src/loading.dart
@@ -134,7 +134,7 @@ class LoadingIndicator extends StatelessWidget {
   }
 
   /// return the animation indicator.
-  _buildIndicator() {
+  Widget _buildIndicator() {
     switch (indicatorType) {
       case Indicator.ballPulse:
         return const BallPulse();


### PR DESCRIPTION
## Summary
- add explicit Widget return types to the five private builders flagged by pub.dev
- preserve existing runtime behavior while satisfying strict_top_level_inference
- format the changed code with Dart 3.13.1

## Why
loading_indicator 4.0.0 currently receives 40/50 static-analysis points because pub.dev reports five missing type annotations. Fixing all five should restore the package to 160/160 under the current scoring rules after the next release.

## Validation
- dart format --output=none --set-exit-if-changed on all five changed files
- flutter analyze with strict_top_level_inference enabled: no issues found
- flutter test: all 18 tests passed
- git diff --check